### PR TITLE
Fixing duplicate Coinbase Ancestors bug with visited list

### DIFF
--- a/src/main/java/com/coinmetrics/BlockchainProcessor.java
+++ b/src/main/java/com/coinmetrics/BlockchainProcessor.java
@@ -63,16 +63,22 @@ public class BlockchainProcessor {
      * @return list of all traversable coins where parent is Coinbase transaction
      */
     public static List<Coin> findCoinbaseAncestors(final Coin coin) {
+        final List<Transaction> visited = new ArrayList<>();
+
         final List<Coin> ancestors = new ArrayList<>();
         final Queue<Coin> queue = new LinkedList<>();
         queue.add(coin);
 
         while (!queue.isEmpty()) {
             final Coin c = queue.poll();
+
             if (c.getCreatorTransaction().isCoinbase()) {
                 ancestors.add(c);
             } else {
-                queue.addAll(c.getCreatorTransaction().getInputs());
+                if (visited.stream().noneMatch(t -> t == c.getCreatorTransaction())) {
+                    visited.add(c.getCreatorTransaction());
+                    queue.addAll(c.getCreatorTransaction().getInputs());
+                }
             }
         }
 

--- a/src/test/java/com/coinmetrics/BlockchainProcessorTest.java
+++ b/src/test/java/com/coinmetrics/BlockchainProcessorTest.java
@@ -67,6 +67,10 @@ public class BlockchainProcessorTest {
         final String address2 = BlockchainProcessor.findMaximumInboundVolumeAddress(b,
                 getEpochSecond("2021-01-01 00:00:13"), getEpochSecond("2021-01-01 00:00:15"));
         Assert.assertEquals(address2, "Erick5");
+
+        final Coin c5 = b.getBlocks().get(3).getTransactions().get(0).getOutputs().get(0);
+        final List<Coin> c5Ancestors = BlockchainProcessor.findCoinbaseAncestors(c5);
+        Assert.assertEquals(c5Ancestors.size(), 1);
     }
 
     @Test


### PR DESCRIPTION
Bug existed in codebase which would create duplicate results for any graph where the same transaction was arrived at via two different paths.

This can be fixed several ways:

- Visited map which ensures you never visit the same transaction twice
- Dedup logic to simply remove any double transactions (less efficient from a traversal perspective, easier from a code impl perspective)

For now since we do not have a fully qualified uid for transactions, we need to compare the object reference directly, so rather then use Set and check if the set contains the transaction in the visited Set we use a list and check if any reference in the list matches what we are looking for. A contains would be significantly more efficient.